### PR TITLE
feat: add contributor over time graph to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,7 @@ docker run --name unlock-music -d -p 8080:80 ix64/unlock-music
 
 - `npm run serve` 可用于开发
 3. 如需构建浏览器扩展，build完成后还需要执行`npm run make-extension`
+
+## 贡献者变化
+
+[![Contributor over time](https://contributor-graph-api.apiseven.com/contributors-svg?chart=contributorOverTime&repo=unlock-music/unlock-music)](https://www.apiseven.com/en/contributor-graph?chart=contributorOverTime&repo=unlock-music/unlock-music)


### PR DESCRIPTION
Hi, community!

To better present how our community grows, we develop a tool to show contributors growing history on [https://github.com/api7/contributor-graph](https://github.com/api7/contributor-graph). Since we found it helpful, we think maybe if it could help some other community.

## WHAT IT IS

Basically, it just shows the contributors growth over time, just like the stargazers over time on the README. It would be the same with stars that we would update the graph each day, so the link would always present the real-time data. There is some other stuff to play around with if you would like to give it a try~

![image](https://user-images.githubusercontent.com/72343596/119219444-3b187580-bb18-11eb-8e72-d112b474bda4.png)

## HOW IT WORKS 

We use Github API to get all commits, try to find the “Github way” to filter commits so the result data would be similar to Github, and then get the first commit time of each user.

Don't hesitate to tell us if there is a better place to present this graph other than this, or there are some other worries or other features you would like to have~🍻